### PR TITLE
Remove pure black font #12

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -702,6 +702,10 @@ form {
   tr {
     border-bottom: 2px solid $color-gray-lightest;
   }
+
+  table {
+    color: $color-gray-dark;
+  }
 }
 
 //------ Dropdowns --------*/

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -36,6 +36,7 @@ label {
 p {
   margin-top: rem(20px);
   margin-bottom: rem(20px);
+  color: $color-gray-dark;
 }
 
 .cf-doc-embed {
@@ -51,7 +52,6 @@ p {
 
   a {
     color: $color-white;
-    text-decoration: underline;
   }
 }
 
@@ -109,6 +109,7 @@ h6 {
     font-family: inherit;
     margin-top: 0;
   }
+  color: $color-gray-dark;
 }
 
 [hidden] {
@@ -686,6 +687,7 @@ form {
   table {
     min-width: rem(400px);
     width: 100%;
+    color: $color-gray-dark;
   }
 }
 

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -3,7 +3,6 @@
 @import 'us_web_design_standards';
 @import 'fonts';
 
-$color-black: #000000;
 $caseflow-background: #f9f9f9;
 
 html,
@@ -287,7 +286,7 @@ dd {
 
 // don't trip the accessibility warning for white on white, even if title isn't visible
 svg title {
-  color: $color-black;
+  color: $color-gray-dark;
 }
 
 .cf-modal {
@@ -304,7 +303,7 @@ svg title {
 
   &::before {
     content: ' ';
-    background: rgba($color-black, .4);
+    background: rgba($color-gray-dark, .4);
     position: fixed;
     height: inherit;
     width: inherit;
@@ -987,7 +986,7 @@ fieldset {
   }
 
   img {
-    box-shadow: 0 0 20px -5px rgba($color-black, .5);
+    box-shadow: 0 0 20px -5px rgba($color-gray-dark, .5);
     clear: both;
     display: block;
     margin: 2rem;

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -680,6 +680,11 @@ form {
 }
 
 //--- Table styles ---*/
+
+table {
+  color: $color-gray-dark;
+}
+
 .cf-table-wrap {
   width: 100%;
   overflow-x: auto;
@@ -687,7 +692,6 @@ form {
   table {
     min-width: rem(400px);
     width: 100%;
-    color: $color-gray-dark;
   }
 }
 
@@ -703,9 +707,6 @@ form {
     border-bottom: 2px solid $color-gray-lightest;
   }
 
-  table {
-    color: $color-gray-dark;
-  }
 }
 
 //------ Dropdowns --------*/


### PR DESCRIPTION
This removes the pure black font that is on the Caseflow apps. Screenshots below:
<img width="984" alt="screen shot 2017-01-12 at 11 49 05 am" src="https://cloud.githubusercontent.com/assets/4773320/21900332/6adec2c6-d8c1-11e6-9591-c7d7d56b6b72.png">
<img width="1004" alt="screen shot 2017-01-12 at 11 50 20 am" src="https://cloud.githubusercontent.com/assets/4773320/21900335/6bc090a2-d8c1-11e6-9322-dc3cb7d9f84b.png">
<img width="1122" alt="screen shot 2017-01-12 at 12 14 53 pm" src="https://cloud.githubusercontent.com/assets/4773320/21900337/6c8e1252-d8c1-11e6-95c1-02fe374a4ff2.png">
<img width="1115" alt="screen shot 2017-01-12 at 12 15 24 pm" src="https://cloud.githubusercontent.com/assets/4773320/21900341/6e043fe4-d8c1-11e6-9d8a-69948775bdfe.png">
