### PR TITLE
Fixing bad hover title

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -412,7 +412,6 @@ svg title {
 
 .cf-logo {
   color: $color-gray-dark;
-  margin-right: rem(10px);
   font-size: 1.7rem;
   display: inline;
 }
@@ -430,6 +429,7 @@ svg title {
 .cf-application-title {
   font-size: 1.7rem;
   font-weight: normal;
+  margin-left: rem(10px);
   display: inline;
 }
 


### PR DESCRIPTION
Hovering over the logo currently looks like: 
<img width="157" alt="screen shot 2017-01-12 at 12 24 18 pm" src="https://cloud.githubusercontent.com/assets/3885236/21912645/4792b62c-d8f5-11e6-896f-80a0adc156ad.png">

With this change it looks like:
<img width="209" alt="screen shot 2017-01-12 at 6 29 26 pm" src="https://cloud.githubusercontent.com/assets/3885236/21912650/52432c64-d8f5-11e6-8de5-6f3d364cba37.png">

**Test Plan**
- [ ] Verify manually
