### PR TITLE
Removing the disabled readonly styling

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -122,11 +122,6 @@ legend {
   white-space: normal;
 }
 
-[disabled],
-[readonly] {
-  background: $color-gray-lightest !important;
-  opacity: .5 !important;
-}
 
 dd {
   margin-left: 0;


### PR DESCRIPTION
This styling makes disabled readonly elements non-508-compliant. And I don't think it's in use anywhere.