### PR TITLE
Marian renovate dropdown and remove line from abbr

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -300,7 +300,7 @@ dd {
     width: 175px;
     height: 1px;
     background-color: $color-gray-lighter;
-    margin: 0px 20px;
+    margin: 0 20px;
   }
 
   li {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -277,6 +277,8 @@ dd {
   top: 2em;
   width: 18rem;
   min-width: 215px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 
   &.active {
     display: block;
@@ -285,7 +287,7 @@ dd {
   a {
     display: block;
     color: $color-gray;
-    padding: 10px 20px;
+    padding: 4px 20px;
     text-decoration: none;
 
     &:hover {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -5,7 +5,8 @@
 
 $cf-background: #f9f9f9;
 $cf-link: #0872b9;
-$cf-drop-shadow: 1px 1px 5px 0px rgba(91,97,107,0.5);
+$cf-drop-shadow-color: rgba(91, 97, 107, 0.5);
+$cf-drop-shadow: 1px 1px 5px 0 $cf-drop-shadow-color;
 
 html,
 body {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -4,6 +4,7 @@
 @import 'fonts';
 
 $caseflow-background: #f9f9f9;
+$caseflow-link: #0872b9;
 
 html,
 body {
@@ -16,7 +17,7 @@ body {
 }
 
 a {
-  color: #0872B9;
+  color: $caseflow-link;
   text-decoration: none;
 }
 
@@ -24,8 +25,13 @@ a:visited {
   color: $color-primary; // Override USWDS
 }
 
-abbr[title]{
-  border-bottom: none;
+abbr {
+  border: 0;
+  text-decoration: none;
+
+  &[title] {
+    border-bottom: none;
+  }
 }
 
 .cf-success {
@@ -100,11 +106,6 @@ p {
 
 .cf-push-right {
   float: right;
-}
-
-abbr {
-  border: 0;
-  text-decoration: none;
 }
 
 h1,

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -299,7 +299,8 @@ dd {
   .dropdown-border {
     width: 175px;
     height: 1px;
-    color: $color-gray-lighter;
+    background-color: $color-gray-lighter;
+    margin: 0px 20px;
   }
 
   li {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -15,8 +15,17 @@ body {
   background: $caseflow-background;
 }
 
+a {
+  color: #0872B9;
+  text-decoration: none;
+}
+
 a:visited {
   color: $color-primary; // Override USWDS
+}
+
+abbr[title]{
+  border-bottom: none;
 }
 
 .cf-success {
@@ -260,13 +269,13 @@ dd {
   @include transition (all 0.2s ease-in-out);
   @extend %overlay;
   border: 1px solid $color-gray-lighter;
-  box-shadow: 0 0 10px -3px $color-gray;
+  box-shadow: 1px 1px 5px $color-gray;
   cursor: pointer;
   display: none;
   text-align: left;
   top: 2em;
   width: 18rem;
-  padding: rem(10px) rem(20px);
+  min-width: 215px;
 
   &.active {
     display: block;
@@ -274,10 +283,17 @@ dd {
 
   a {
     display: block;
+    color: $color-gray;
+    padding: 10px 20px;
+    text-decoration: none;
+
+    &:hover {
+      background-color: $color-gray;
+      color: $color-white;
+    }
   }
 
   li {
-    padding: rem(10px) 0;
 
     &:last-child {
       border-top: 1px solid $color-gray-lighter;
@@ -651,7 +667,7 @@ form {
   &:hover {
     background-color: inherit;
     color: $color-primary-darker;
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   &--confirm {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -3,8 +3,9 @@
 @import 'us_web_design_standards';
 @import 'fonts';
 
-$caseflow-background: #f9f9f9;
-$caseflow-link: #0872b9;
+$cf-background: #f9f9f9;
+$cf-link: #0872b9;
+$cf-drop-shadow: rgba(91,97,107,0.5);
 
 html,
 body {
@@ -13,11 +14,11 @@ body {
 
 body {
   padding-bottom: 70px;
-  background: $caseflow-background;
+  background: $cf-background;
 }
 
 a {
-  color: $caseflow-link;
+  color: $cf-link;
   text-decoration: none;
 }
 
@@ -265,7 +266,7 @@ dd {
   @include transition (all 0.2s ease-in-out);
   @extend %overlay;
   border: 1px solid $color-gray-lighter;
-  box-shadow: 1px 1px 5px $color-gray;
+  box-shadow: 1px 1px 5px 0px $cf-drop-shadow;
   cursor: pointer;
   display: none;
   text-align: left;
@@ -295,7 +296,7 @@ dd {
     width: 175px;
     height: 1px;
     background-color: $color-gray-lighter;
-    margin: 0 20px;
+    margin: 5px 20px;
   }
 
   li {
@@ -968,7 +969,7 @@ fieldset {
 // Date picker overrides
 //----------------------------*/
 .ui-datepicker {
-  background: $caseflow-background;
+  background: $cf-background;
   box-shadow: 0 0 30px rgba($color-base, .8);
 
   &-header {
@@ -1024,7 +1025,7 @@ fieldset {
     }
 
     td {
-      background: $caseflow-background;
+      background: $cf-background;
       border-color: $color-gray-light;
       padding: 0;
       text-align: right;

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -5,7 +5,7 @@
 
 $cf-background: #f9f9f9;
 $cf-link: #0872b9;
-$cf-drop-shadow: rgba(91,97,107,0.5);
+$cf-drop-shadow: 1px 1px 5px 0px rgba(91,97,107,0.5);
 
 html,
 body {
@@ -266,7 +266,7 @@ dd {
   @include transition (all 0.2s ease-in-out);
   @extend %overlay;
   border: 1px solid $color-gray-lighter;
-  box-shadow: 1px 1px 5px 0px $cf-drop-shadow;
+  box-shadow: $cf-drop-shadow;
   cursor: pointer;
   display: none;
   text-align: left;
@@ -299,12 +299,6 @@ dd {
     margin: 5px 20px;
   }
 
-  li {
-
-    &:last-child {
-      border-top: 1px solid $color-gray-lighter;
-    }
-  }
 }
 
 //------ Modals --------*/

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -287,13 +287,19 @@ dd {
   a {
     display: block;
     color: $color-gray;
-    padding: 4px 20px;
+    padding: 10px 20px;
     text-decoration: none;
 
     &:hover {
       background-color: $color-gray;
       color: $color-white;
     }
+  }
+
+  .dropdown-border {
+    width: 175px;
+    height: 1px;
+    color: $color-gray-lighter;
   }
 
   li {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -285,7 +285,7 @@ dd {
   a {
     display: block;
     color: $color-gray;
-    padding: 10px 20px;
+    padding: 4px 20px;
     text-decoration: none;
 
     &:hover {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -285,7 +285,7 @@ dd {
   a {
     display: block;
     color: $color-gray;
-    padding: 4px 20px;
+    padding: 10px 20px;
     text-decoration: none;
 
     &:hover {


### PR DESCRIPTION
References issue #13 
<img width="264" alt="screen shot 2017-01-24 at 1 57 21 pm" src="https://cloud.githubusercontent.com/assets/4773320/22261984/10399046-e23d-11e6-956e-0b29c1bc5792.png">

And issue #21 
<img width="355" alt="screen shot 2017-01-24 at 1 46 17 pm" src="https://cloud.githubusercontent.com/assets/4773320/22261632/a3c3542a-e23b-11e6-84ed-d17331ebcc5c.png">

PTAL @KHarshawat @lakohl 

Issue #13 will also require adding the following to `app/view/layouts/application.html.erb` on the last menu bullet point to _all_ Caseflow apps: `<div class="dropdown-border"></div>`
