### PR TITLE
Add logger to be used by all applications

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -1,0 +1,24 @@
+def get_session(req)
+  session_cookie_name = Rails.application.config.session_options[:key]
+  req.cookie_jar.encrypted[session_cookie_name] || {}
+end
+
+ip = Rails.env.production? ? IPSocket.getaddress(Socket.gethostname) : 'localhost'
+
+log_tags = [:host, ip, Time.now]
+
+log_tags << lambda { |req|
+  session = get_session(req)
+  user = session["user"]
+  ["id", "email"].map { | attr | user[attr] }.join(" ") if user
+}
+
+# don't mix worker and RAILS http logs
+if !ENV["IS_WORKER"].blank?
+  log_tags << "jobs-worker"
+end
+
+Rails.application.config.log_tags = log_tags
+
+# log sidekiq to application logger (defaults to stdout)
+Sidekiq::Logging.logger = Rails.logger


### PR DESCRIPTION
Create `logger` in commons to be used by all applications:
Format:
`[host, ip, timestamp, css_id, email]`

![image](https://cloud.githubusercontent.com/assets/3811786/22837677/9481c198-ef8f-11e6-8e51-01209718e7c6.png)


connects #790