### PR TITLE
Fixed spinning logo size

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -832,7 +832,7 @@ table {
       height: 90%;
       position: relative;
       background: image-url('icons/cf-logo-pill.svg') center no-repeat;
-      background-size: 80% 80%;
+      background-size: 65%;
       @include animation(spin 2s linear infinite);
     }
   }


### PR DESCRIPTION
Connect https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/327

Original size worked in Chrome/Safari/IE/Opera but looked weird in FF.  This fixes it.