### PR TITLE
Added bottom padding to footer - connects #22

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -561,8 +561,9 @@ div {
   > div {
     box-sizing: border-box;
     height: 125px;
-    padding-top: 50px !important;
+    padding: 50px 0px;
     border-top: 1px solid $color-gray-lighter;
+    overflow: auto;
   }
 }
 

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -561,7 +561,7 @@ div {
   > div {
     box-sizing: border-box;
     height: 125px;
-    padding: 50px 0px;
+    padding: 50px 0;
     border-top: 1px solid $color-gray-lighter;
     overflow: auto;
   }


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow-commons/issues/22

Turns out `!important` wasn't needed; `overflow: auto` enables the bottom padding to remain under the footer contents even though they're floated.