### PR TITLE
Marian issue 19 change header styles for all the apps

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -130,8 +130,8 @@ h6 {
 }
 
 h2 {
-  &[id="page-title"]{
-    margin-left: 0px;
+  &[id="page-title"] {
+    margin-left: 0;
   }
 }
 

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -465,7 +465,7 @@ div {
 }
 
 .cf-logo-name {
-  color: $color-gray-dark;
+  color: $color-gray;
   font-weight: normal;
 }
 
@@ -480,6 +480,7 @@ div {
 }
 
 .cf-application-title {
+  color: $color-gray;
   font-size: 1.7rem;
   font-weight: normal;
   display: inline;

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -472,6 +472,10 @@ div {
   font-size: 1.7rem;
   font-weight: normal;
   display: inline;
+
+  &[id="page-title"]{
+    margin-left: 0px;
+  }
 }
 
 .cf-app-screen {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -473,7 +473,7 @@ div {
   font-weight: normal;
   display: inline;
 
-  &[id="page-title"]{
+  [id="page-title"]{
     margin-left: 0px;
   }
 }

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -464,6 +464,11 @@ div {
 
 }
 
+.cf-logo-name {
+  color: $color-gray-dark;
+  font-weight: normal;
+}
+
 .cf-logo-image {
   display: inline-block;
   vertical-align: middle;

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -124,6 +124,12 @@ h6 {
   color: $color-gray-dark;
 }
 
+h2 {
+  &[id="page-title"]{
+    margin-left: 0px;
+  }
+}
+
 [hidden] {
   display: none;
 }
@@ -472,10 +478,6 @@ div {
   font-size: 1.7rem;
   font-weight: normal;
   display: inline;
-
-  [id="page-title"]{
-    margin-left: 0px;
-  }
 }
 
 .cf-app-screen {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -462,7 +462,7 @@ div {
   display: inline-block;
   vertical-align: middle;
   margin-top: -2px;
-  margin-right: .5em;
+  margin-right: 15px;
   height: 32px;
   width: 32px;
   background-size: 32px;
@@ -471,7 +471,6 @@ div {
 .cf-application-title {
   font-size: 1.7rem;
   font-weight: normal;
-  margin-left: rem(10px);
   display: inline;
 }
 
@@ -1007,7 +1006,8 @@ fieldset {
 
 .cf-help-divider {
   margin: 30px 0;
-  border: 1px solid $color-gray-light;
+  color: $color-gray-lighter;
+  border-bottom: 1px;
 }
 
 ul {


### PR DESCRIPTION
This PR fills the following criteria that @KHarshawat-gov and @lakohl had mentioned last week regarding the header:
* No sub-title: no symbol
* Page title: use **>** as symbol between app name and page title
* User reference: use **|** as symbol between app name and user's information view
Also fixes other things from #19 

Logos:
<img width="455" alt="screen shot 2017-02-20 at 3 20 39 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141805/966b714e-f786-11e6-8678-c64edcb51c17.png">
<img width="133" alt="screen shot 2017-02-20 at 3 20 49 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141806/966beb06-f786-11e6-839c-c2fc1004f5d9.png">
<img width="200" alt="screen shot 2017-02-20 at 3 20 59 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141807/966d348e-f786-11e6-89d9-23dbce1d6827.png">
<img width="516" alt="screen shot 2017-02-20 at 3 21 06 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141808/966e6674-f786-11e6-99bb-a6543d1bc1ed.png">
<img width="327" alt="screen shot 2017-02-20 at 3 21 37 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141809/966f9da0-f786-11e6-9e19-da4ba7718d5f.png">
<img width="201" alt="screen shot 2017-02-20 at 3 21 44 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141810/96712256-f786-11e6-88f0-619f53b9fe91.png">
<img width="186" alt="screen shot 2017-02-20 at 3 22 45 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141812/9674f7f0-f786-11e6-820e-9b2385ea94b8.png">
<img width="343" alt="screen shot 2017-02-20 at 3 22 57 pm" src="https://cloud.githubusercontent.com/assets/4773320/23141811/9674c49c-f786-11e6-8ef2-af90c8db0cd0.png">
