### PR TITLE
Changing gray table header to white

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -772,6 +772,10 @@ table {
     border-bottom: 2px solid $color-gray-lightest;
   }
 
+  thead th {
+    background-color: $color-white;
+  }
+
 }
 
 // ===========================*


### PR DESCRIPTION
Looks like a change to the web design standards made table headers gray. This overrides it for caseflow tables.

**Test Plan**
- [x] Look at tables in caseflow-dispatch to ensure the table header is now white