### PR TITLE
Work history table

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -769,7 +769,7 @@ table {
   }
 
   tr {
-    border-bottom: 1px solid $color-gray-lightest;
+    border-bottom: 1px solid $color-gray-light;
   }
 
   th {

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -772,7 +772,7 @@ table {
     border-bottom: 1px solid $color-gray-light;
   }
 
-  th {
+  thead th {
     background-color: $color-white;
   }
 

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -772,7 +772,7 @@ table {
     border-bottom: 1px solid $color-gray-lightest;
   }
 
-  thead th {
+  th {
     background-color: $color-white;
   }
 

--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -769,7 +769,7 @@ table {
   }
 
   tr {
-    border-bottom: 2px solid $color-gray-lightest;
+    border-bottom: 1px solid $color-gray-lightest;
   }
 
   thead th {


### PR DESCRIPTION
This reduces the lines between the rows to 1px and reverts the current table headers back to white after the USWDS gem upgrade.
<img width="951" alt="screen shot 2017-03-03 at 12 09 57 pm" src="https://cloud.githubusercontent.com/assets/4773320/23561042/998449d2-000a-11e7-9659-3374489102c5.png">
<img width="987" alt="screen shot 2017-03-03 at 12 10 22 pm" src="https://cloud.githubusercontent.com/assets/4773320/23561043/9984e39c-000a-11e7-86f4-da7081f1e51f.png">

References https://github.com/department-of-veterans-affairs/caseflow/issues/1045