### PR TITLE
Display some stats in hours

### DIFF
--- a/app/assets/javascripts/stats/dashboard.js
+++ b/app/assets/javascripts/stats/dashboard.js
@@ -165,8 +165,9 @@ window.Dashboard = (function(d3, moment) {
   }
   function timeFormat(seconds) {
     return !seconds ? '?? <span class="cf-stat-unit">sec</span>' :
-      seconds > 60 ? format(seconds / 60) + ' <span class="cf-stat-unit">min</span>' :
-      format(seconds) + ' <span class="cf-stat-unit">sec</span>'
+      seconds < 60 ? format(seconds) + ' <span class="cf-stat-unit">sec</span>' :
+      seconds / 60 < 60 ? format(seconds / 60) + ' <span class="cf-stat-unit">min</span>' :
+        format(seconds / 60 / 60) + ' <span class="cf-stat-unit">hours</span>'
   }
 
   // public

--- a/app/assets/javascripts/stats/dashboard.js
+++ b/app/assets/javascripts/stats/dashboard.js
@@ -167,7 +167,7 @@ window.Dashboard = (function(d3, moment) {
     return !seconds ? '?? <span class="cf-stat-unit">sec</span>' :
       seconds < 60 ? format(seconds) + ' <span class="cf-stat-unit">sec</span>' :
       seconds / 60 < 60 ? format(seconds / 60) + ' <span class="cf-stat-unit">min</span>' :
-      seconds / 60 / 60 < 24 ? format(seconds / 60 / 60) + ' <span class="cf-stat-unit">hours</span>'
+      seconds / 60 / 60 < 24 ? format(seconds / 60 / 60) + ' <span class="cf-stat-unit">hours</span>' :
         format(seconds / 60 / 60 / 24) + ' <span class="cf-stat-unit">days</span>'
   }
 

--- a/app/assets/javascripts/stats/dashboard.js
+++ b/app/assets/javascripts/stats/dashboard.js
@@ -167,7 +167,8 @@ window.Dashboard = (function(d3, moment) {
     return !seconds ? '?? <span class="cf-stat-unit">sec</span>' :
       seconds < 60 ? format(seconds) + ' <span class="cf-stat-unit">sec</span>' :
       seconds / 60 < 60 ? format(seconds / 60) + ' <span class="cf-stat-unit">min</span>' :
-        format(seconds / 60 / 60) + ' <span class="cf-stat-unit">hours</span>'
+      seconds / 60 / 60 < 24 ? format(seconds / 60 / 60) + ' <span class="cf-stat-unit">hours</span>'
+        format(seconds / 60 / 60 / 24) + ' <span class="cf-stat-unit">days</span>'
   }
 
   // public


### PR DESCRIPTION
This PR lets us display some stats in hours/days. 

Connects #819

<img width="718" alt="screen shot 2017-04-20 at 1 36 43 pm" src="https://cloud.githubusercontent.com/assets/4306128/25244376/744683a8-25ce-11e7-8105-acf9a8b25966.png">

<img width="702" alt="screen shot 2017-04-20 at 1 49 05 pm" src="https://cloud.githubusercontent.com/assets/4306128/25244833/4105acb0-25d0-11e7-8742-e847c225d822.png">

