### PR TITLE
Prepend env name in Redis namespace to avoid conflicts between test a…

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -62,8 +62,9 @@ class FeatureToggle
   end
 
   def self.client
-    namespace = (Rails.env.development? || Rails.env.test?) ? "feature_toggle_#{Rails.env}" : "feature_toggle"
-    @client ||= Redis::Namespace.new(namespace.to_sym, redis: redis)
+    # Use separate Redis namespace for test to avoid conflicts between test and dev environments
+    namespace = Rails.env.test? ? :feature_toggle_test : :feature_toggle
+    @client ||= Redis::Namespace.new(namespace, redis: redis)
   end
 
   def self.redis

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -62,7 +62,8 @@ class FeatureToggle
   end
 
   def self.client
-    @client ||= Redis::Namespace.new(:feature_toggle, redis: redis)
+    namespace = (Rails.env.development? || Rails.env.test?) ? "feature_toggle_#{Rails.env}" : "feature_toggle"
+    @client ||= Redis::Namespace.new(namespace.to_sym, redis: redis)
   end
 
   def self.redis


### PR DESCRIPTION
…nd dev envs


connects #84  

Once this is merged, I will create a PR to update commons in caseflow