### PR TITLE
Add users option to feature toggle

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -55,16 +55,13 @@ class FeatureToggle
   # Method to check if a given feature is enabled for a user
   def self.enabled?(feature, user: nil)
     return false unless features.include?(feature)
+
     data = get_data(feature)
-
-    # If we do not have any users or regional office restrictions
-    # then the feature is enabled *globally* and we accept *all* users
-    return true if data.empty?
-
     regional_offices = data[:regional_offices]
     users = data[:users]
 
     enabled = false
+    enabled = true if enabled_globally?(users: users, regional_offices: regional_offices)
     enabled = true if enabled_for_user?(users: users, user: user)
     enabled = true if enabled_for_regional_office?(regional_offices: regional_offices, user: user)
 
@@ -86,6 +83,12 @@ class FeatureToggle
 
   class << self
     private
+
+    # If we do not have any users or regional office restrictions
+    # then the feature is enabled *globally* and we accept *all* users
+    def enabled_globally?(users:, regional_offices:)
+      users.nil? && regional_offices.nil?
+    end
 
     # If users key is set, check if the feature
     # is enabled for the user's css_id

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -20,9 +20,7 @@ class FeatureToggle
              value: regional_offices)
     end
 
-    if users.present?
-      enable(feature: feature, key: :users, value: users)
-    end
+    enable(feature: feature, key: :users, value: users) if users.present?
 
     true
   end
@@ -41,13 +39,13 @@ class FeatureToggle
       return true
     end
 
-      disable(feature: feature,
-              key: :regional_offices,
-              value: regional_offices)
+    disable(feature: feature,
+            key: :regional_offices,
+            value: regional_offices)
 
-      disable(feature: feature,
-              key: :users,
-              value: users)
+    disable(feature: feature,
+            key: :users,
+            value: users)
 
     true
   end
@@ -65,19 +63,8 @@ class FeatureToggle
     users = data[:users]
 
     enabled = false
-
-
-    # If users key is set, check if the feature
-    # is enabled for the user's css_id
-    if users.present?
-      enabled = true if user && users.include?(user.css_id)
-    end
-
-    # if regional_offices key is set, check if the feature
-    # is enabled for the user's ro
-    if regional_offices.present?
-      enabled = true if user && regional_offices.include?(user.regional_office)
-    end
+    enabled = true if enabled_for_user?(users: users, user: user)
+    enabled = true if enabled_for_regional_office?(regional_offices: regional_offices, user: user)
 
     enabled
   end
@@ -97,6 +84,18 @@ class FeatureToggle
 
   class << self
     private
+
+    # If users key is set, check if the feature
+    # is enabled for the user's css_id
+    def enabled_for_user?(users:, user:)
+      users.present? && user && users.include?(user.css_id)
+    end
+
+    # if regional_offices key is set, check if the feature
+    # is enabled for the user's ro
+    def enabled_for_regional_office?(regional_offices:, user:)
+      regional_offices.present? && user && regional_offices.include?(user.regional_office)
+    end
 
     def enable(feature:, key:, value:)
       data = get_data(feature)

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -10,6 +10,7 @@ class FeatureToggle
   # Examples:
   # FeatureToggle.enable!(:foo)
   # FeatureToggle.enable!(:bar, regional_offices: ["RO01", "RO02"])
+  # FeatureToggle.enable!(:bar, users: ["CSS_ID_1", "CSS_ID_2"])
   def self.enable!(feature, regional_offices: nil, users: nil)
     # redis method: sadd (add item to a set)
     client.sadd FEATURE_LIST_KEY, feature unless features.include?(feature)
@@ -29,6 +30,7 @@ class FeatureToggle
   # Examples:
   # FeatureToggle.disable!(:foo)
   # FeatureToggle.disable!(:bar, regional_offices: ["RO01", "RO02"])
+  # FeatureToggle.disable!(:bar, users: ["CSS_ID_1", "CSS_ID_2"])
   def self.disable!(feature, regional_offices: nil, users: nil)
     unless regional_offices || users
       client.multi do


### PR DESCRIPTION
- Support toggling a feature for individual users by css_id

Features supported:
- Enabling a feature by RO `FeatureToggle.enable!(:feature_name, regional_offices: ["RO33"])`
- Enabling a feature by individual user `FeatureToggle.enable!(:feature, users: ["CSS_ID"])`
- Enabling a feature for an RO and individual (non-RO) user: `FeatureToggle.enable!(:feature, users: ["CSS_ID"], regional_offices: ["RO33"])`

