### PR TITLE
msg-screen-text color by lara

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -1100,6 +1100,7 @@ fieldset {
   text-align: center;
   margin-left: auto;
   margin-right: auto;
+  color: $color-gray;
 }
 
 .cf-list-checklist {


### PR DESCRIPTION
<img width="486" alt="screen shot 2017-05-16 at 7 57 39 am" src="https://cloud.githubusercontent.com/assets/18075411/26104783/5ef87d64-3a0d-11e7-9cf7-a076f37ee8e8.png">

### Found similar text on other utility pages, might as well make it all the same:

<img width="695" alt="screen shot 2017-05-16 at 7 58 52 am" src="https://cloud.githubusercontent.com/assets/18075411/26104827/877af8ca-3a0d-11e7-8d0b-3ad1502937ef.png">
