### PR TITLE
log cache to separate file

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -34,7 +34,7 @@ logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(output))
 # Rails has a lot of loggers
 Rails.logger = logger
 ActiveSupport::Dependencies.logger = logger
-Rails.cache.logger = logger
+Rails.cache.logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(File.join(Rails.root, "log", "cache.log")))
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::Base.logger = logger
 end


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/caseflow/issues/2407

- Stops the prometheus spam of all the `Cache read` messages
- Instead redirects the log to `log/cache.log` like this:
```
[dsva@ip-172-30-70-145 ~]$ head /opt/caseflow-certification/src/log/cache.log
[2017-07-11 08:21:57 -0400] Cache read: prometheus_last_summary_observation_vacols_request_latency_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:57 -0400] Cache write: prometheus_last_summary_observation_vacols_request_latency_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_postgres_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_postgres_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_postgres_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_vacols_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_vacols_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_vacols_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_background_jobs_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_background_jobs_summary ({:expires_in=>86400 seconds})
```

This is from a custom setup in `UAT`