### PR TITLE
Allow the Redis namespace for feature toggles to be customized

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -74,7 +74,7 @@ class FeatureToggle
   end
 
   # Set this to customize the redis namespace to prevent collisions
-  def cache_namespace=(namespace)
+  def self.cache_namespace=(namespace)
     @cache_namespace = namespace
     @client = nil
   end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -73,10 +73,16 @@ class FeatureToggle
     feature_enabled_hash(feature) if features.include?(feature)
   end
 
+  # Set this to customize the redis namespace to prevent collisions
+  def cache_namespace=(namespace)
+    @cache_namespace = namespace
+    @client = nil
+  end
+
   def self.client
     # Use separate Redis namespace for test to avoid conflicts between test and dev environments
-    namespace = Rails.env.test? ? :feature_toggle_test : :feature_toggle
-    @client ||= Redis::Namespace.new(namespace, redis: redis)
+    @cache_namespace ||= Rails.env.test? ? :feature_toggle_test : :feature_toggle
+    @client ||= Redis::Namespace.new(@cache_namespace, redis: redis)
   end
 
   def self.redis


### PR DESCRIPTION
allows parallel tests to not run over each other in redis.

Ideally we should be using `Rails.cache` which is the abstraction we use for all our other caching needs. We may have had a good reason for not doing that. Do you remember @aroltsch?

connects https://github.com/department-of-veterans-affairs/caseflow/issues/2458