### PR TITLE
Replace all instances of the color-secondary-dark style with color-secondary

### DIFF
--- a/app/assets/stylesheets/caseflow_main.scss
+++ b/app/assets/stylesheets/caseflow_main.scss
@@ -48,7 +48,7 @@ abbr {
 }
 
 .cf-error {
-  color: $color-secondary-dark;
+  color: $color-secondary;
 }
 
 label {
@@ -237,7 +237,7 @@ dd {
   height: .8em;
 
   path {
-    fill: $color-secondary-dark;
+    fill: $color-secondary;
   }
 }
 
@@ -549,7 +549,7 @@ div {
 
 .cf-nav-whatsnew {
   &::after {
-    color: $color-secondary-dark;
+    color: $color-secondary;
     content: '\00A0\2605';
     display: inline-block;
     font-size: 1.25rem;
@@ -824,10 +824,10 @@ form {
 
   &--confirm {
     &:visited {
-      color: $color-secondary-dark;
+      color: $color-secondary;
     }
 
-    color: $color-secondary-dark;
+    color: $color-secondary;
     font-weight: bold;
   }
 
@@ -893,7 +893,7 @@ table {
   b {
     &::after {
       content: '* ';
-      color: $color-secondary-dark;
+      color: $color-secondary;
       font-family: inherit;
       font-weight: bold;
       font-style: normal;


### PR DESCRIPTION
`$color-secondary-dark` has been deprecated in favor of `$color-secondary`. They are both a relatively similar red color (...one is just darker than the other) so the signals implied to the user by the color should not change. Additionally, the [recent color audit revealed](https://github.com/department-of-veterans-affairs/appeals-design-research/issues/559#issuecomment-347263051) that this color is only currently being used by Caseflow Certification.