### PR TITLE
Add CI step to confirm version number increased

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ rvm:
   - 2.3.0
 before_install: gem install bundler -v 1.12.5
 
-branches:
-  only:
-    - master
-
 script:
   - if [[ -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)"; exit 1; fi
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rvm:
   - 2.3.0
 before_install: gem install bundler -v 1.12.5
 
+branches:
+  - only:
+    - master
+
 script:
   - if [[ -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)"; exit 1; fi
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.3.0
 before_install: gem install bundler -v 1.12.5
 
+branches:
+  only:
+    - master
 
 script:
   - if [[ -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)"; exit 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install: gem install bundler -v 1.12.5
 
 
 script:
+  - if [[ -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)"; exit 1; fi
   - bundle exec rake
 
 services:

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.1".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.1.6".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
There have been more than 100 commits to the caseflow-commons repo since [we last updated the gem version number](https://github.com/department-of-veterans-affairs/caseflow-commons/commit/6a0cb8e42025beb46f0d80f4e35af52191042bc3#diff-0b623a76abd8bbf440c37d9cf079c957). This PR adds a command to ensure that a travis build fails if the version number was not changed (in reality this PR only mandates that the file itself changed, but I think it communicates the intent). Recommend we use [semantic versioning](https://semver.org/) for this gem's version number if we are not already.