### PR TITLE
Update version check to avoid running on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ branches:
     - master
 
 script:
-  - if [[ -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)"; exit 1; fi
+  - if [[ $(git rev-parse --abbrev-ref HEAD) != "master" && -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then
+      echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)";
+      exit 1;
+    fi
   - bundle exec rake
 
 services:

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.3".freeze
+  VERSION = "0.2.4".freeze
 end


### PR DESCRIPTION
If we are currently on the master branch, do not run the check to determine if lib/caseflow/version.rb is different than the corresponding file in origin/master (since we are already on that branch and they should always be the same).

Expect this PR's build to fail the first time because I didn't update the version number so that I can test that this check works.