### PR TITLE
Catch new error type

### DIFF
--- a/app/services/caseflow/s3_service.rb
+++ b/app/services/caseflow/s3_service.rb
@@ -45,7 +45,7 @@ module Caseflow
       ensure
         tempfile.close!
       end
-    rescue Aws::S3::Errors::NoSuchKey
+    rescue Aws::S3::Errors::NotFound
       nil
     end
 

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.5".freeze
+  VERSION = "0.2.6".freeze
 end


### PR DESCRIPTION
Connects #114. Error introduced in #124.

AWS::S3::Client.get_object() throws an `Aws::S3::Errors::NoSuchKey` error when the object does not exist. AWS::S3::Object.download_file() throws an `Aws::S3::Errors::NotFound` error when the object does not exist (strangely, you can instantiate an instance of AWS::S3::Object without triggering that error, which is only triggered when we call its `download_file()` method). We changed our code to use the latter interface but were still catching the previous error. This change makes it so that we catch the new error.
  