### PR TITLE
Add Danger to caseflow-commons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.3.0
 before_install: gem install bundler -v 1.12.5
 
+before_script:
+  - bundle exec danger
+
 branches:
   - only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ branches:
     - master
 
 script:
-  - if [[ $(git rev-parse --abbrev-ref HEAD) != "master" && -z $(git diff origin/master -- lib/caseflow/version.rb) ]]; then
-      echo "Update version number when updating caseflow commons (lib/caseflow/version.rb)";
-      exit 1;
-    fi
   - bundle exec rake
 
 services:

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,16 @@
+# Sometimes it's a README fix, or something like that - which isn't relevant for
+# including in a project's CHANGELOG for example
+declared_trivial = github.pr_title.include? "#trivial"
+
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+warn("PR is classed as Work in Progress") if github.pr_title.include? "WIP"
+
+# Warn when there is a big PR
+warn("Big PR") if git.lines_of_code > 500
+
+# Don't let testing shortcuts get into master by accident
+fail("focus: true is left in test") if `git diff #{github.base_commit} spec/ | grep ':focus => true'`.length > 1
+
+if git.modified_files.grep(/lib\/caseflow\/version.rb/).empty?
+  fail("Please bump the `lib/caseflow/version.rb` version")
+end

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development, :test do
   gem "timecop"
   gem "redis-rails"
   gem "redis-namespace"
+  gem "danger"
 end

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.6".freeze
+  VERSION = "0.2.7".freeze
 end


### PR DESCRIPTION
This includes a check for the version and will Danger will fail if the version.rb is not updated.

We will now see this on any PR that does not bump the version. 

 
![screenshot 2018-01-05 15 41 30](https://user-images.githubusercontent.com/31223104/34627755-d3e41e96-f22f-11e7-911e-1a7f8209e343.png)


  