### PR TITLE
Add sync! method and spec tests

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -86,7 +86,7 @@ class FeatureToggle
   end
 
   def self.redis
-    @redis ||= Redis.new(url: "redis://localhost:6379/0/cache/")
+    @redis ||= Redis.new(url: Rails.application.secrets.redis_url_cache)
   end
 
   # Example of config_file:

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -127,13 +127,13 @@ class FeatureToggle
         if enable_all_value
           enable!(feature_from_cache)
         else
+          # Details in cache (example: {:users=>["Good", "Bad", "Ugly"], :regional_offices=>["TR"]})
           hash_from_cache = details_for(feature_from_cache)
           if hash_from_cache.empty?
             disable!(feature_from_cache)
             enable!(feature_from_cache, users: users_value) unless users_key.nil?
             enable!(feature_from_cache, regional_offices: offices_value) unless offices_key.nil?
           else
-            # Details existing in Redis (example: {:users=>["Good", "Bad", "Ugly"], :regional_offices=>["TR"]})
             users_key_cache = hash_from_cache.keys.select { |key| key == :users }[0]
             offices_key_cache = hash_from_cache.keys.select { |key| key == :regional_offices }[0]
 

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -4,6 +4,25 @@ describe FeatureToggle do
   let(:user1) { OpenStruct.new(regional_office: "RO03", css_id: "5") }
   let(:user2) { OpenStruct.new(regional_office: "RO07", css_id: "7") }
   let(:user3) { OpenStruct.new(regional_office: "RO07", css_id: "CSSID") }
+  features_config = [
+    {
+      feature: "all_feature",
+      enable_all: true
+    },
+    {
+      feature: "users_feature",
+      users: %w(Good Bad Ugly)
+    },
+    {
+      feature: "offices_feature",
+      regional_offices: ["O.K.Corral", "Alamo"]
+    },
+    {
+      feature: "users_and_offices",
+      users: %w(Good Bad Ugly),
+      regional_offices: ["O.K.Corral", "Alamo", "Tombstone"]
+    }
+  ]
 
   before :each do
     Rails.stub(:application) { FakeApplication.instance }
@@ -248,6 +267,65 @@ describe FeatureToggle do
       context "when user is not passed" do
         let(:user) { nil }
         it { is_expected.to eq false }
+      end
+    end
+  end
+
+  context ".sync!" do
+    before :each do
+      FeatureToggle.redis.flushall
+    end
+
+    context "when there are no existing features enabled" do
+      before do
+        FeatureToggle.sync!(features_config)
+      end
+
+      it "sets new features" do
+        expect(FeatureToggle.details_for(:all_feature)).to eql {}
+        expect(FeatureToggle.details_for(:users_feature)[:users]).to eql %w(Good Bad Ugly)
+        expect(FeatureToggle.details_for(:offices_feature)[:regional_offices]).to eql ["O.K.Corral", "Alamo"]
+      end
+    end
+
+    context "when existing features are enabled for all" do
+      before do
+        FeatureToggle.enable!(:all_feature)
+        FeatureToggle.enable!(:users_feature)
+        FeatureToggle.enable!(:offices_feature)
+        FeatureToggle.enable!(:users_and_offices)
+        FeatureToggle.sync!(features_config)
+      end
+
+      it "all_feature stays the same" do
+        expect(FeatureToggle.details_for(:all_feature)).to eql {}
+        expect(FeatureToggle.details_for(:users_feature)[:users]).to eql %w(Good Bad Ugly)
+        expect(FeatureToggle.details_for(:offices_feature)[:regional_offices]).to eql ["O.K.Corral", "Alamo"]
+        expect(FeatureToggle.details_for(:users_and_offices)[:users]).to eql %w(Good Bad Ugly)
+        expect(FeatureToggle.details_for(:users_and_offices)[:regional_offices]).to eql ["O.K.Corral", "Alamo", "Tombstone"]
+      end
+    end
+
+    context "where existing features and new hash have common members" do
+      before do
+        FeatureToggle.enable!(:all_feature)
+        FeatureToggle.enable!(:some_other_feature)
+        FeatureToggle.enable!(:users_feature, users: ["Good", "Il Buono"])
+        FeatureToggle.enable!(:offices_feature, regional_offices: ["O.K.Corral", "Alamo", "Rio Bravo"])
+        FeatureToggle.enable!(:users_and_offices, users: ["Good", "Bad", "Il Brutto"])
+        FeatureToggle.enable!(:users_and_offices, regional_offices: ["O.K.Corral", "Alamo", "Rio Bravo"])
+        FeatureToggle.sync!(features_config)
+      end
+
+      it "enables only new members" do
+        expect(FeatureToggle.features.sort).to eq [:all_feature, :offices_feature, :users_and_offices, :users_feature]
+        expect(FeatureToggle.details_for(:all_feature)).to eql {}
+        expect(FeatureToggle.details_for(:some_other_feature)).to eql nil
+        expect(FeatureToggle.details_for(:users_feature)[:users]).to eql %w(Good Bad Ugly)
+        expect(FeatureToggle.details_for(:offices_feature)[:regional_offices]).to eql ["O.K.Corral", "Alamo"]
+        expect(FeatureToggle.details_for(:users_feature)[:users]).to eql %w(Good Bad Ugly)
+        expect(FeatureToggle.details_for(:users_and_offices)[:users]).to eql %w(Good Bad Ugly)
+        expect(FeatureToggle.details_for(:users_and_offices)[:regional_offices]).to eql ["O.K.Corral", "Alamo", "Tombstone"]
       end
     end
   end


### PR DESCRIPTION
Here's the logic:

| hash-in-cache  |  hash-in-file  | action | 
|---------------- | :------------:  | -----------:|
{}    |                                              -              |      disable all
{}    |                                              {:enable_all=> true}    |                  do nothing
{}    |                                              {:users=> ["2"]}    |                  disable all, enable users
{}    |                                              {:offices=>["RO2"]}    |                  disable all, enable offices
{}    |                                              {:users=> ["1"], :offices=>["RO2"]}    |          disable all, enable users and offices
| | | |
{ :users=>["1"]}    |                                      -             |       disable all
{ :users=>["1"]}    |                                      {:enable_all=> true}    |                  enable all
{ :users=>["1"]}    |                                      {:users=> ["2"]}    |                  disable difference in users, enable users
{:users=>["1"]}    |                                      {:offices=>["RO2"]}    |                  disable all, enable offices
{ :users=>["1"]}    |                                      {:users=> ["1"], :offices=>["RO2"]}    |          disable difference in users, enable users and offices
| | | |
{ :offices=>["RO1"]}    |                                      -             |       disable all
{ :offices=>["RO1"]}    |                                      {:enable_all=> true}    |                  enable all
{ :offices=>["RO1"]}    |                                      {:users=> ["2"]}    |                  disable all, enable users
{:offices=>["RO1"]}    |                                      {:offices=>["RO1"]}    |                  disable difference in offices, enable offices
{ :offices=>["RO1"]}    |                                      {:users=> ["1"], :offices=>["RO2"]}    |          disable difference in offices, enable users and offices
| | | |
{:users=>["1"], :offices=>["RO1"]}    |                              -           |         disable all
{:users=>["1"], :offices=>["RO1"]}    |                                {:enable_all=> true}    |                  enable all
{:users=>["1"], :offices=>["RO1"]}    |                              {:users=> ["2"]}    |                  disable difference in users, enable users and offices
{:users=>["1"], :offices=>["RO1"]}    |                              { :offices=>["RO2"]}    |                  disable users and disable difference in offices, enable users and offices
{:users=>["1"], :offices=>["RO1"]}    |                              {:users=> ["2"], :offices=>["RO2"]}    |          disable difference in users and offices, enable users and offices