### PR TITLE
Fix issues with stats

### DIFF
--- a/app/models/caseflow/stats.rb
+++ b/app/models/caseflow/stats.rb
@@ -75,7 +75,7 @@ module Caseflow
     end
 
     def self.calculate_all!
-      INTERVALS.each do |interval|
+      self::INTERVALS.each do |interval|
         {
           hourly: 0...24,
           daily: 0...30,
@@ -114,7 +114,7 @@ module Caseflow
     end
 
     def calculate_cache_id
-      id = "stats-#{range_start.year}"
+      id = "#{self.class.name}-#{range_start.year}"
 
       case interval
       when :monthly then id + "-#{range_start.month}"

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.82".freeze
+  VERSION = "0.2.83".freeze
 end

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -79,7 +79,7 @@ describe Caseflow::Stats do
     class WonderfulThing
     end
 
-    class Stats < Caseflow::Stats
+    class TestStats < Caseflow::Stats
       CALCULATIONS = {
         wonderful_things_happened: lambda do |_range|
           ObjectSpace.each_object(WonderfulThing).count
@@ -87,12 +87,12 @@ describe Caseflow::Stats do
       }.freeze
     end
 
-    let(:stats) { Stats.new(time: Stats.now, interval: "daily") }
+    let(:stats) { TestStats.new(time: TestStats.now, interval: "daily") }
     subject { stats.values }
 
     context "when cached stat values exist" do
       before do
-        Rails.cache.write("stats-2017-1-1", wonderful_things_happened: 55)
+        Rails.cache.write("TestStats-2017-1-1", wonderful_things_happened: 55)
       end
 
       it "loads cached value" do


### PR DESCRIPTION
This PR addresses two issues with `Caseflow::Stats`

First, is that the stats cache key is not unique to the type of stats (ie. `stats-2018-1` is the key for both intake stats and certification stats), so these are overwriting each other in Caseflow.

Second, allow subclasses to define their own intervals. Not all stat categories need the same intervals.