### PR TITLE
Add option to recalculate all stats, not just the current ones

### DIFF
--- a/app/models/caseflow/stats.rb
+++ b/app/models/caseflow/stats.rb
@@ -17,7 +17,7 @@ module Caseflow
     end
 
     def values
-      @values ||= load_values || calculate_and_save_values!
+      @values ||= load_values || calculate_and_save_values!(clear_cache: false)
     end
 
     def complete?

--- a/app/models/caseflow/stats.rb
+++ b/app/models/caseflow/stats.rb
@@ -47,8 +47,8 @@ module Caseflow
       }[interval]
     end
 
-    def calculate_and_save_values!
-      return true if complete?
+    def calculate_and_save_values!(clear_cache:)
+      return true if complete? && !clear_cache
       calculated_values = calculate_values
       calculated_values[:complete] = Stats.now >= range_finish
       Rails.cache.write(cache_id, calculated_values)
@@ -74,7 +74,7 @@ module Caseflow
       new(interval: interval, time: offset_time)
     end
 
-    def self.calculate_all!
+    def self.calculate_all!(clear_cache: false)
       self::INTERVALS.each do |interval|
         {
           hourly: 0...24,
@@ -83,7 +83,7 @@ module Caseflow
           monthly: 0...24
         }[interval].each do |i|
           offset(interval: interval, time: Stats.now, offset: i)
-            .calculate_and_save_values!
+            .calculate_and_save_values!(clear_cache: clear_cache)
         end
       end
     end

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Caseflow
-  VERSION = "0.2.10".freeze
+  VERSION = "0.2.11".freeze
 end


### PR DESCRIPTION
Intake stats can come in at any time, so unfortunately our optimization of only calculating the lastest stats doesn't work