### PR TITLE
Add fiscal yearly to stats

### DIFF
--- a/app/assets/javascripts/stats/dashboard.js
+++ b/app/assets/javascripts/stats/dashboard.js
@@ -19,7 +19,7 @@ window.Dashboard = (function(d3, moment) {
       case 'daily': str += date.format('MMMM D'); break
       case 'weekly': str += 'the week of ' + date.format('MMMM D'); break
       case 'monthly': str += date.format(i < 12 ? 'MMMM' : 'MMMM YYYY'); break
-      case 'fiscal yearly': str += 'FY ' + date.format('YYYY'); break
+      case 'fiscal_yearly': str += 'FY ' + date.format('YYYY'); break
       default: str += date.format('X')
       }
 

--- a/app/assets/javascripts/stats/dashboard.js
+++ b/app/assets/javascripts/stats/dashboard.js
@@ -19,6 +19,7 @@ window.Dashboard = (function(d3, moment) {
       case 'daily': str += date.format('MMMM D'); break
       case 'weekly': str += 'the week of ' + date.format('MMMM D'); break
       case 'monthly': str += date.format(i < 12 ? 'MMMM' : 'MMMM YYYY'); break
+      case 'fiscal yearly': str += 'FY ' + date.format('YYYY'); break
       default: str += date.format('X')
       }
 

--- a/app/models/caseflow/stats.rb
+++ b/app/models/caseflow/stats.rb
@@ -113,11 +113,11 @@ module Caseflow
     private
 
     def beginning_of_fiscal_year(time)
-      self.class.timezone.local(time.year - (time.month >= 10 ? 0 : 1), 10, 1).beginning_of_day
+      self.class.timezone.local(time.year - ((time.month >= 10) ? 0 : 1), 10, 1).beginning_of_day
     end
 
     def end_of_fiscal_year(time)
-      self.class.timezone.local(time.year + (time.month >= 10 ? 1 : 0), 9, 30).end_of_day
+      self.class.timezone.local(time.year + ((time.month >= 10) ? 1 : 0), 9, 30).end_of_day
     end
 
     def load_values

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -12,7 +12,10 @@ task :security do
   )
 
   puts "running bundle-audit to check for insecure dependencies..."
-  exit!(1) unless ShellCommand.run("bundle-audit update")
+  unless ShellCommand.run("bundle-audit update")
+    puts Rainbow("Bundle Audit failed.").red
+    exit!(1)
+  end
 
   # TODO(lowell): Remove this ignore after we have upgraded rubocop.
   audit_result = ShellCommand.run("bundle-audit check --ignore CVE-2017-8418")

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -10,7 +10,8 @@ describe Caseflow::Stats do
     Rails.cache.clear
   end
 
-  let(:time) { Timecop.freeze(Time.utc(2017, 1, 0o1, 20, 59, 0)) }
+  let(:time) { Timecop.freeze(Time.utc(2017, 1, 1, 20, 59, 0)) }
+  let(:timezone) { Caseflow::Stats.timezone }
   after(:all) { Timecop.return }
 
   context "#range" do
@@ -31,9 +32,17 @@ describe Caseflow::Stats do
       it { is_expected.to eq time.beginning_of_week..(time + 1.week).beginning_of_week }
     end
 
-    context "calculates yearly range" do
+    context "calculates monthly range" do
       let(:interval) { "monthly" }
       it { is_expected.to eq time.beginning_of_month..(time + 1.month).beginning_of_month }
+    end
+
+    context "calculates fiscal yearly range" do
+      let(:interval) { "fiscal_yearly" }
+      let(:expected_range_start) { timezone.local(2016, 10, 1).beginning_of_day }
+      let(:expected_range_end) { timezone.local(2017, 9, 30).end_of_day }
+
+      it { is_expected.to eq expected_range_start..expected_range_end }
     end
   end
 


### PR DESCRIPTION
Adds tooling to allow for the "fiscal yearly" interval for Stats classes. By default it is not calculated. You have to explicitly add it to the `INTERVALS` object of the stats class.

Tested on Intake Stats:
![screen shot 2018-01-30 at 4 35 25 pm](https://user-images.githubusercontent.com/1596259/35595778-dac12f8c-05e5-11e8-8fc4-6a3232a252db.png)

connects department-of-veterans-affairs/caseflow#4460