### PR TITLE
Nemo/Validate input for setting features

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -106,7 +106,7 @@ class FeatureToggle
   #   }
   # ]
   def self.sync!(config_file_string)
-    config_hash = YAML.safe_load(config_file_string)
+    config_hash = validate_config(config_file_string)
     existing_features = features
     client.multi do
       features_from_file = []
@@ -192,6 +192,40 @@ class FeatureToggle
 
     def set_data(feature, data)
       client.set(feature, data.to_json)
+    end
+
+  # • when env hash has a key that doesn't belong to {feature, enable_all, users, regional_offices} set
+  # • when feature as key is not present in env hash
+  # • when (enable_all is not present AND (users AND regional_offices are not present)) OR (enable_all is present AND (users OR regional_offices are present))
+  # • when env hash has empty values
+  # • when value for key feature is not a String
+  # • when value for key feature is an empty string
+  # • when enable_all key exists and enable_all key is not TrueClass
+  # • when value for users key OR value for regional_offices key exists and it's not an Array
+  # • when value for users key OR value for regional_offices key exists and it's an empty array
+  # • when value for users key OR value for regional_offices key exists and members of its array are not strings
+  # • when value for users key OR value for regional_offices key exists and members of its array are empty string(s)
+
+    def validate_config(config)
+      config_hash = YAML.safe_load(config)
+      config_hash.each do|feature_hash|
+        raise "Unknown key found in config object" unless (feature_hash.keys - ["feature", "enable_all", "users", "regional_offices"]).empty? 
+        raise "Missing key in config object" unless feature_hash.keys.include?("feature")
+        raise "Ambiguous input" unless feature_hash.keys.include?("enable_all") ^ (feature_hash.keys.include?("users") || feature_hash.keys.include?("regional_offices"))
+        raise "Missing values in config object" if feature_hash.value?(nil)
+        raise "Feature is not String" unless feature_hash["feature"].is_a? String
+        raise "Empty value in config object" if feature_hash["feature"].empty?
+        raise "enable_all has invalid value" if feature_hash.key?("enable_all") && !feature_hash["enable_all"].is_a?(TrueClass)
+        raise "users value should be an array" if feature_hash.key?("users") && !feature_hash["users"].is_a?(Array)
+        raise "regional_offices value should be an array" if feature_hash.key?("regional_offices") && !feature_hash["regional_offices"].is_a?(Array)
+        raise "Empty value for users" if feature_hash.key?("users") && feature_hash["users"].empty?
+        raise "Empty value for regional_offices" if feature_hash.key?("regional_offices") && feature_hash["regional_offices"].empty?
+        raise "User has to be a string" if feature_hash.key?("users") && feature_hash["users"].any?{|x| !x.is_a? String}
+        raise "Regional office has to be a string" if feature_hash.key?("regional_offices") && feature_hash["regional_offices"].any?{|x| !x.is_a? String}
+        raise "Empty string for user" if feature_hash.key?("users") && feature_hash["users"].any?{|x| x.empty?}
+        raise "Empty string for regional_office" if feature_hash.key?("regional_offices") && feature_hash["regional_offices"].any?{|x| x.empty?}
+      end
+      config_hash
     end
   end
 end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -327,5 +327,145 @@ describe FeatureToggle do
         expect(FeatureToggle.details_for(:users_and_offices)[:regional_offices]).to eql ["O.K.Corral", "Alamo", "Tombstone"]
       end
     end
+
+    context "validate config object" do
+      
+      it "fails when env hash has a key that doesn't belong"  do
+        features_config = '[
+           {
+              feature: "all_feature",
+              fake_key: true,
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Unknown key found in config object")
+      end
+
+      it "fails when env hash has no key 'feature'"  do
+        features_config = '[
+           {
+              enable_all: true
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Missing key in config object")
+      end
+
+      it "fails when ambiguous input"  do
+        features_config = '[
+           {
+              feature: "reader",
+              enable_all: true,
+              users: ["Good"]
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Ambiguous input")
+      end
+
+      it "fails when there are no values specified"  do
+        features_config = '[
+           {
+              feature: "reader",
+              enable_all: 
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Missing values in config object")
+      end
+
+      it "fails when feature is not a string"  do
+        features_config = '[
+           {
+              feature: true,
+              enable_all: true
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Feature is not String")
+      end
+
+
+      it "fails when feature is empty string"  do
+        features_config = '[
+           {
+              feature: "",
+              enable_all: true
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty value in config object")
+      end
+
+      it "fails when enable_all has other than true value" do
+        features_config = '[
+           {
+              feature: "reader",
+              enable_all: false
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("enable_all has invalid value")
+      end
+
+
+      it "fails when users value is not an array"  do
+        features_config = '[
+           {
+              feature: "reader",
+              users: true
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("users value should be an array")
+      end
+
+      it "fails when regional_offices value is not an array"  do
+        features_config = '[
+           {
+              feature: "reader",
+              regional_offices: true
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("regional_offices value should be an array")
+      end
+
+      it "fails when users value is empty array"  do
+        features_config = '[
+           {
+              feature: "reader",
+              users: []
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty value for users")
+      end
+
+      it "fails when regional_offices value is empty array"  do
+        features_config = '[
+           {
+              feature: "reader",
+              regional_offices: []
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty value for regional_offices")
+      end
+
+      it "fails when values for users are not strings" do
+        features_config = '[
+           {
+              feature: "reader",
+              users: [true]
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("User has to be a string")
+      end
+
+      it "fails when values for regional offices are specified, but empty"  do
+        features_config = '[
+           {
+              feature: "reader",
+              regional_offices: [true]
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Regional office has to be a string")
+      end
+
+      it "fails when values for users are specified, but empty" do
+        features_config = '[
+           {
+              feature: "reader",
+              users: [""]
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty string for user")
+      end
+
+      it "fails when values for regional offices are specified, but empty"  do
+        features_config = '[
+           {
+              feature: "reader",
+              regional_offices: [""]
+            }]'
+        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty string for regional_office")
+      end
+    end
   end
 end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -329,60 +329,58 @@ describe FeatureToggle do
     end
 
     context "validate config object" do
-      
-      it "fails when env hash has a key that doesn't belong"  do
+      it "fails when env hash has a key that doesn't belong" do
         features_config = '[
            {
               feature: "all_feature",
               fake_key: true,
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Unknown key found in config object")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Unknown key found in config object")
       end
 
-      it "fails when env hash has no key 'feature'"  do
+      it "fails when env hash has no key 'feature'" do
         features_config = '[
            {
               enable_all: true
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Missing key in config object")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Missing feature key in config object")
       end
 
-      it "fails when ambiguous input"  do
+      it "fails when ambiguous input" do
         features_config = '[
            {
               feature: "reader",
               enable_all: true,
               users: ["Good"]
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Ambiguous input")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Ambiguous input")
       end
 
-      it "fails when there are no values specified"  do
+      it "fails when there are no values specified" do
         features_config = '[
            {
               feature: "reader",
-              enable_all: 
+              enable_all:
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Missing values in config object")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Missing values in config object")
       end
 
-      it "fails when feature is not a string"  do
+      it "fails when feature is not a string" do
         features_config = '[
            {
               feature: true,
               enable_all: true
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Feature is not String")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Feature value should be a string")
       end
 
-
-      it "fails when feature is empty string"  do
+      it "fails when feature is empty string" do
         features_config = '[
            {
               feature: "",
               enable_all: true
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty value in config object")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Empty string in feature")
       end
 
       it "fails when enable_all has other than true value" do
@@ -391,44 +389,43 @@ describe FeatureToggle do
               feature: "reader",
               enable_all: false
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("enable_all has invalid value")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("enable_all value has to be true")
       end
 
-
-      it "fails when users value is not an array"  do
+      it "fails when users value is not an array" do
         features_config = '[
            {
               feature: "reader",
               users: true
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("users value should be an array")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("users value should be an array")
       end
 
-      it "fails when regional_offices value is not an array"  do
+      it "fails when regional_offices value is not an array" do
         features_config = '[
            {
               feature: "reader",
               regional_offices: true
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("regional_offices value should be an array")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("regional_offices value should be an array")
       end
 
-      it "fails when users value is empty array"  do
+      it "fails when users value is empty array" do
         features_config = '[
            {
               feature: "reader",
               users: []
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty value for users")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Empty array for users")
       end
 
-      it "fails when regional_offices value is empty array"  do
+      it "fails when regional_offices value is empty array" do
         features_config = '[
            {
               feature: "reader",
               regional_offices: []
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty value for regional_offices")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Empty array for regional_offices")
       end
 
       it "fails when values for users are not strings" do
@@ -437,16 +434,16 @@ describe FeatureToggle do
               feature: "reader",
               users: [true]
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("User has to be a string")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("users values have to be strings")
       end
 
-      it "fails when values for regional offices are specified, but empty"  do
+      it "fails when values for regional offices are specified, but empty" do
         features_config = '[
            {
               feature: "reader",
               regional_offices: [true]
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Regional office has to be a string")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("regional_offices values have to be strings")
       end
 
       it "fails when values for users are specified, but empty" do
@@ -455,16 +452,16 @@ describe FeatureToggle do
               feature: "reader",
               users: [""]
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty string for user")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Empty string in users")
       end
 
-      it "fails when values for regional offices are specified, but empty"  do
+      it "fails when values for regional offices are specified, but empty" do
         features_config = '[
            {
               feature: "reader",
               regional_offices: [""]
             }]'
-        expect {FeatureToggle.sync!(features_config)}.to raise_error("Empty string for regional_office")
+        expect { FeatureToggle.sync!(features_config) }.to raise_error("Empty string in regional_offices")
       end
     end
   end


### PR DESCRIPTION
Connects to #144 

Added validations with all test scenarios. Scenarios:
- when env hash has a key that doesn't belong to {`feature`, `enable_all`, `users`, `regional_offices`} set
- when `feature` as key is not present in env hash 
- when (`enable_all` is not present AND (`users` AND `regional_offices` are not present))  
  OR  
 (`enable_all` is present AND (`users` OR `regional_offices` are present))
- when env hash has empty values
- when value for key `feature` is not a String
- when value for key `feature` is an empty string
- when `enable_all` key exists and `enable_all` key is not TrueClass
- when value for `users` key OR value for `regional_offices` key exists and it's not an Array
- when value for `users` key OR value for `regional_offices` key exists and it's an empty array
- when value for `users` key OR value for `regional_offices` key exists and members of its array are not strings
- when value for `users` key OR value for `regional_offices` key exists and members of its array are empty string(s)
