### PR TITLE
Nemo/Add rails 5 compatibility for ActiveSupport::Dependencies logger

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -34,7 +34,12 @@ logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(output))
 # Rails has a lot of loggers
 # This line causes double logging in development
 Rails.logger = logger unless Rails.env.development?
-ActiveSupport::Dependencies.logger = logger
+
+# This should be removed once we switch to Rails5 since ActiveSupport::Dependencies.logger is deprecated
+if ActiveSupport::Dependencies.respond_to? :logger= then
+  ActiveSupport::Dependencies.logger = logger
+end
+
 Rails.cache.logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(File.join(Rails.root, "log", "cache.log")))
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::Base.logger = logger

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -35,7 +35,7 @@ logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(output))
 # This line causes double logging in development
 Rails.logger = logger unless Rails.env.development?
 
-# This should be removed once we switch to Rails5 since ActiveSupport::Dependencies.logger is deprecated
+# TODO Rails5Upgrade - Clean this up after upgrading
 ActiveSupport::Dependencies.logger = logger if ActiveSupport::Dependencies.respond_to? :logger=
 
 

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -36,9 +36,8 @@ logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(output))
 Rails.logger = logger unless Rails.env.development?
 
 # This should be removed once we switch to Rails5 since ActiveSupport::Dependencies.logger is deprecated
-if ActiveSupport::Dependencies.respond_to? :logger= then
-  ActiveSupport::Dependencies.logger = logger
-end
+ActiveSupport::Dependencies.logger = logger if ActiveSupport::Dependencies.respond_to? :logger=
+
 
 Rails.cache.logger = ActiveSupport::TaggedLogging.new(LoggerWithTimestamp.new(File.join(Rails.root, "log", "cache.log")))
 ActiveSupport.on_load(:active_record) do

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end


### PR DESCRIPTION
Connects to #151 
Since all our apps depend on caseflow gem, this can't be removed until all of the apps are upgraded to Rails 5. However, to avoid getting RuntimeError during/after apps upgrade, the conditional was introduced. 

For more details about this rails deprecation see https://github.com/rails/rails/pull/24198