### PR TITLE
read from .security.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.12.5
+  - 2.5.3
+before_install: gem install bundler -v 1.17
 
 before_script:
   - bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.0
-before_install: gem install bundler -v 1.12
+before_install: gem install bundler -v 1.17
 
 before_script:
   - bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.3
-before_install: gem install bundler -v 1.17
+  - 2.3.0
+before_install: gem install bundler -v 1.12
 
 before_script:
   - bundle exec danger

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Caseflow
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/caseflow`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Common libs for the Caseflow suite of applications.
 
 ## Installation
 
@@ -19,10 +17,6 @@ And then execute:
 Or install it yourself as:
 
     $ gem install caseflow
-
-## Usage
-
-TODO: Write usage instructions here
 
 ## Development
 

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.3.8"
+  VERSION = "0.3.9"
 end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -19,14 +19,16 @@ task :security do
   end
 
   snoozed_cves = []
-  security_yml = Rails.root.join('.security.yml')
+  security_yml = File.expand_path('../../.security.yml', __dir__)
+
+  puts "Looking for #{security_yml}"
 
   if File.exist?(security_yml)
-    puts "reading #{security_yml} config"
+    puts "Reading #{security_yml} config"
     security_config = YAML.load_file(security_yml)
     security_config["CVES"].each do |cve, ignore_until|
       puts "cve #{cve} ignore_until #{ignore_until}"
-      snoozed_cves << { cve_name: cve, until: ignore_until }
+      snoozed_cves << { cve_name: cve, until: ignore_until.to_time }
     end
   end
 

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -19,9 +19,9 @@ task :security do
   end
 
   snoozed_cves = []
-  security_yml = File.expand_path('../../.security.yml', __dir__)
+  security_yml = File.expand_path("../../.security.yml", __dir__)
   if defined? Rails
-    security_yml = Rails.root.join('.security.yml')
+    security_yml = Rails.root.join(".security.yml")
   end
 
   puts "Looking for #{security_yml}"
@@ -31,12 +31,12 @@ task :security do
     security_config = YAML.load_file(security_yml)
     security_config["CVES"].each do |cve, ignore_until|
       puts "cve #{cve} ignore_until #{ignore_until}"
-      snoozed_cves << { cve_name: cve, until: ignore_until.to_time }
+      snoozed_cves << { cve_name: cve, until: ignore_until }
     end
   end
 
   alerting_cves = snoozed_cves
-    .select { |cve| cve[:until] >= Time.now.utc }
+    .select { |cve| cve[:until] >= Time.now.utc.to_date }
     .map { |cve| cve[:cve_name] }
 
   audit_cmd = "bundle-audit check --ignore=#{alerting_cves.join(' ')}"

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -2,6 +2,7 @@
 
 require "open3"
 require "rainbow"
+require "yaml"
 require_relative "support/shell_command"
 
 desc "shortcut to run all linting tools, at the same time."
@@ -17,14 +18,37 @@ task :security do
     exit!(1)
   end
 
-  # TODO(lowell): Remove this ignore after we have upgraded rubocop.
-  audit_result = ShellCommand.run("bundle-audit check --ignore CVE-2017-8418")
+  snoozed_cves = []
+  security_yml = Rails.root.join('.security.yml')
+
+  if File.exist?(security_yml)
+    puts "reading #{security_yml} config"
+    security_config = YAML.load_file(security_yml)
+    security_config["CVES"].each do |cve, ignore_until|
+      puts "cve #{cve} ignore_until #{ignore_until}"
+      snoozed_cves << { cve_name: cve, until: ignore_until }
+    end
+  end
+
+  alerting_cves = snoozed_cves
+    .select { |cve| cve[:until] >= Time.now.utc }
+    .map { |cve| cve[:cve_name] }
+
+  audit_cmd = "bundle-audit check --ignore=#{alerting_cves.join(' ')}"
+
+  puts audit_cmd
+
+  audit_result = ShellCommand.run(audit_cmd)
 
   puts "\n"
   if brakeman_result && audit_result
     puts Rainbow("Passed. No obvious security vulnerabilities.").green
   else
-    puts Rainbow("Failed. Security vulnerabilities were found.").red
+    puts Rainbow(
+      "Failed. Security vulnerabilities were found. Find the dependency in Gemfile.lock,\n"\
+      "then specify a safe version of the dependency in the Gemfile (preferred) or\n"\
+      "snooze the CVE in .security.yml for a week."
+    ).red
     exit!(1)
   end
 end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -20,6 +20,9 @@ task :security do
 
   snoozed_cves = []
   security_yml = File.expand_path('../../.security.yml', __dir__)
+  if defined? Rails
+    security_yml = Rails.root.join('.security.yml')
+  end
 
   puts "Looking for #{security_yml}"
 


### PR DESCRIPTION
Adds support for a `.security.yml` file to configure the security overrides for a given repo.

This should allow both Caseflow and Efolder to use this common rake task and configure it per-repo.

Example `.security.yml`

```yaml
CVES:
  CVE-2017-8418: 2019-03-30
  CVE-2015-9284: 2019-12-31
```