### PR TITLE
tests pass Ruby 2.5.3

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.5.3
 before_install: gem install bundler -v 1.17
 
 before_script:

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock"
 
   spec.add_runtime_dependency "bourbon", "4.2.7"
   spec.add_runtime_dependency "neat"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "dotenv"
 
   spec.add_runtime_dependency "bourbon", "4.2.7"
   spec.add_runtime_dependency "neat"

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.3.9"
+  VERSION = "0.4.0"
 end

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 
 describe Caseflow::Stats do
   before do
-    Rails.stub(:cache) { FakeCache.instance }
+    allow(Rails).to receive(:cache) { FakeCache.instance }
     Rails.cache.clear
   end
   let(:time_to_freeze) { Time.utc(2017, 1, 1, 20, 59, 0) }

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -24,7 +24,7 @@ describe FeatureToggle do
     }]'
 
   before :each do
-    Rails.stub(:application) { FakeApplication.instance }
+    allow(Rails).to receive(:application) { FakeApplication.instance }
     FeatureToggle.redis.flushall
   end
 

--- a/spec/services/functions_spec.rb
+++ b/spec/services/functions_spec.rb
@@ -5,7 +5,7 @@ describe Functions do
   let(:user2) { OpenStruct.new(css_id: "7") }
 
   before :each do
-    Rails.stub(:application) { FakeApplication.instance }
+    allow(Rails).to receive(:application) { FakeApplication.instance }
     Functions.delete_all_keys!
   end
 

--- a/spec/services/pushgateway_service_spec.rb
+++ b/spec/services/pushgateway_service_spec.rb
@@ -3,9 +3,6 @@ require "pry"
 
 describe Caseflow::PushgatewayService do
   context "mock tests" do
-    before { WebMock.disable_net_connect! }
-    after { WebMock.allow_net_connect! }
-
     context "service offline" do
       before do
         WebMock.disable_net_connect!(allow_localhost: true)
@@ -19,7 +16,7 @@ describe Caseflow::PushgatewayService do
 
     context "service online and unhealthy" do
       before do
-        stub_request(:get, "http://127.0.0.1:9091/-/healthy").to_return(body: "Error", status: ["503", "Service Unavailable"] )
+        stub_request(:get, "http://127.0.0.1:9091/-/healthy").to_return(body: "Error", status: ["503", "Service Unavailable"])
       end
 
       it "unhealthy when service generates non-2xx status" do

--- a/spec/services/s3_service_spec.rb
+++ b/spec/services/s3_service_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 require "pry"
+require "dotenv/load"
 
 describe Caseflow::S3Service do
+  before { WebMock.allow_net_connect! } # these are live tests
+
   context "store_file" do
     let(:filename) { "somefilename.ext" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require "caseflow/pushgateway_service"
 require "stats"
 require "feature_toggle"
 require "functions"
+require "webmock/rspec"
 
 class FakeCache
   # make it a singleton so there is only one instance shared between the tests and application code


### PR DESCRIPTION
The FakeWeb gem is not maintained.

Allow for running live S3 tests locally with dotenv gem.

Resolves #161 