### PR TITLE
Fix CI tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Metrics/BlockLength:
 Rails:
   Enabled: true
 
+Rails/RakeEnvironment:
+  Enabled: false
+
 Rails/Output:
   Exclude:
     - 'lib/**/*.rb'
@@ -73,9 +76,6 @@ Metrics/AbcSize:
   Max: 30
 
 Style/DoubleNegation:
-  Enabled: false
-
-Performance/RedundantBlockCall:
   Enabled: false
 
 Style/NegatedIf:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.3
-  TargetRailsVersion: 4.2
+  TargetRubyVersion: 2.5
+  TargetRailsVersion: 5.2
 
   Include:
     - '**/Rakefile'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 AllCops:
   TargetRubyVersion: 2.5
   TargetRailsVersion: 5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.5.3
-#before_install: gem install bundler -v 1.17
 cache: bundler --without development
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 rvm:
   - 2.5.3
-before_install: gem install bundler -v 1.17
+#before_install: gem install bundler -v 1.17
+cache: bundler --without development
 
 before_script:
   - bundle exec danger

--- a/Gemfile
+++ b/Gemfile
@@ -2,18 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in caseflow.gemspec
 gemspec
-
-group :development, :test do
-  gem "brakeman"
-  gem "bundler-audit"
-  gem "danger"
-  gem "pry"
-  gem "redis-namespace"
-  gem "redis-rails"
-  gem "rubocop", "~> 0.52.1", require: false
-  gem "timecop"
-end
-
-group :test do
-  gem "fakeweb", "~> 1.3"
-end

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-#  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"
@@ -29,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
-  spec.add_runtime_dependency "jquery-rails"
+  spec.add_runtime_dependency "redis"
+#  spec.add_runtime_dependency "jquery-rails"
   spec.add_runtime_dependency "d3-rails"
   spec.add_runtime_dependency "momentjs-rails"
 

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+#  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -16,17 +16,18 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "brakeman"
+  spec.add_development_dependency "bundler-audit"
+  spec.add_development_dependency "danger"
+  spec.add_development_dependency "dotenv"
+  spec.add_development_dependency "fakeweb"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "rainbow"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "bundler-audit"
-  spec.add_development_dependency "fakeweb"
-  spec.add_development_dependency "webmock"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "dotenv"
-  spec.add_development_dependency "danger"
-  spec.add_development_dependency "rainbow"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "timecop"
+  spec.add_development_dependency "webmock"
 
   spec.add_runtime_dependency "bourbon", "4.2.7"
   spec.add_runtime_dependency "neat"
@@ -34,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
   spec.add_runtime_dependency "redis-namespace"
   spec.add_runtime_dependency "redis-rails"
-# TODO drop d3-rails as Caseflow does not use it?
+  # TODO drop d3-rails as Caseflow does not use it?
   spec.add_runtime_dependency "d3-rails"
   spec.add_runtime_dependency "momentjs-rails"
 

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rainbow"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -28,8 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
-  spec.add_runtime_dependency "redis"
-#  spec.add_runtime_dependency "jquery-rails"
+  spec.add_runtime_dependency "redis-namespace"
+  spec.add_runtime_dependency "redis-rails"
+# TODO drop d3-rails as Caseflow does not use it?
   spec.add_runtime_dependency "d3-rails"
   spec.add_runtime_dependency "momentjs-rails"
 

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-rails"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -6,8 +6,8 @@ require "caseflow/version"
 Gem::Specification.new do |spec|
   spec.name          = "caseflow"
   spec.version       = Caseflow::VERSION
-  spec.authors       = ["Chris Given"]
-  spec.email         = ["christopher.given@va.gov"]
+  spec.authors       = ["Caseflow"]
+  spec.email         = ["caseflowops@va.gov"]
 
   spec.summary       = "Shared resources for VA Caseflow applications"
 

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "dotenv"
+  spec.add_development_dependency "danger"
 
   spec.add_runtime_dependency "bourbon", "4.2.7"
   spec.add_runtime_dependency "neat"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "danger"
+  spec.add_development_dependency "rainbow"
 
   spec.add_runtime_dependency "bourbon", "4.2.7"
   spec.add_runtime_dependency "neat"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -18,11 +18,15 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler-audit"
+  spec.add_development_dependency "fakeweb"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "danger"
   spec.add_development_dependency "rainbow"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "timecop"
 
   spec.add_runtime_dependency "bourbon", "4.2.7"
   spec.add_runtime_dependency "neat"

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -4,13 +4,12 @@ require "open3"
 require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
-task lint: :environment do
+task :lint do
   opts = ENV["CI"] ? "" : "--auto-correct"
   cmd = "bundle exec rubocop #{opts} --color"
   puts "running #{cmd}"
   rubocop_result = ShellCommand.run(cmd)
-  puts rubocop_result.inspect
-  puts "\n"
+  puts "rubocop output: #{rubocop_result.inspect}"
   if rubocop_result
     puts Rainbow("Passed. Everything looks stylish!").green
   else

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -7,7 +7,7 @@ desc "shortcut to run all linting tools, at the same time."
 task :lint do
   opts = ENV["CI"] ? "" : "--auto-correct"
   puts "running rubocop..."
-  rubocop_result = ShellCommand.run("rubocop #{opts} --color")
+  rubocop_result = ShellCommand.run("bundle exec rubocop #{opts} --color")
 
   puts "\n"
   if rubocop_result

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -13,6 +13,7 @@ task :lint do
   if rubocop_result
     puts Rainbow("Passed. Everything looks stylish!").green
   else
+    puts rubocop_result.inspect
     puts Rainbow("Failed. Linting issues were found.").red
     exit!(1)
   end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -4,7 +4,7 @@ require "open3"
 require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
-task :lint do
+task lint: :environment do
   opts = ENV["CI"] ? "" : "--auto-correct"
   cmd = "bundle exec rubocop #{opts} --color"
   puts "running #{cmd}"

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -6,14 +6,14 @@ require "rainbow"
 desc "shortcut to run all linting tools, at the same time."
 task :lint do
   opts = ENV["CI"] ? "" : "--auto-correct"
-  puts "running rubocop..."
-  rubocop_result = ShellCommand.run("bundle exec rubocop #{opts} --color")
-
+  cmd = "bundle exec rubocop #{opts} --color"
+  puts "running #{cmd}"
+  rubocop_result = ShellCommand.run(cmd)
+  puts rubocop_result.inspect
   puts "\n"
   if rubocop_result
     puts Rainbow("Passed. Everything looks stylish!").green
   else
-    puts rubocop_result.inspect
     puts Rainbow("Failed. Linting issues were found.").red
     exit!(1)
   end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -6,7 +6,7 @@ require "yaml"
 require_relative "support/shell_command"
 
 desc "shortcut to run all linting tools, at the same time."
-task :security do
+task security: :environment do
   puts "running Brakeman security scan..."
   brakeman_result = ShellCommand.run(
     "brakeman --exit-on-warn --run-all-checks --confidence-level=2"

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -6,7 +6,7 @@ require "yaml"
 require_relative "support/shell_command"
 
 desc "shortcut to run all linting tools, at the same time."
-task security: :environment do
+task :security do
   puts "running Brakeman security scan..."
   brakeman_result = ShellCommand.run(
     "brakeman --exit-on-warn --run-all-checks --confidence-level=2"


### PR DESCRIPTION
This gem had a broken mix of Gemfile and caseflow.gemspec dependency management.

Since it is a gem, use `caseflow.gemspec` like our other gems.

Adds missing gems, cleans up rubocop rules, CI working again.