### PR TITLE
Re-add jquery-rails dependency

### DIFF
--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
+  spec.add_runtime_dependency "jquery-rails"
   spec.add_runtime_dependency "redis-namespace"
   spec.add_runtime_dependency "redis-rails"
   # TODO drop d3-rails as Caseflow does not use it?

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.4.5"
+  VERSION = "0.4.6"
 end


### PR DESCRIPTION
### Description

Re-add the `jquery-rails` gem

Gem had been removed in [this](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/168/commits/24bb42a9ff5e1bb69f675c31938c089bb848b33e) PR, however when Caseflow upraded to the next [version](https://github.com/department-of-veterans-affairs/caseflow/pull/13930/files) without the gem it caused a CircleCi [failure](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/29631/workflows/e7ebb229-35a5-4822-9811-943c6007d21f/jobs/108805).

It was determined in the slack discussion below the gem should be re-added for now until the root issue of the failure can be determined.

### Background
https://dsva.slack.com/archives/C2ZAMLK88/p1586460388238400?thread_ts=1586280242.142000&cid=C2ZAMLK88