### PR TITLE
Support enabling/disabling features with users objects

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -22,8 +22,8 @@ class FeatureToggle
              value: regional_offices)
     end
 
-    enable(feature: feature, key: :users, value: users) if users.present?
-
+    enable(feature: feature, key: :users, value: css_ids_for_users(users)) if users.present?
+    
     true
   end
 
@@ -44,7 +44,7 @@ class FeatureToggle
 
     disable(feature: feature,
             key: :users,
-            value: users)
+            value: css_ids_for_users(users))
 
     # disable the feature completely if users and regional_offices become empty
     # to avoid accidentally enabling the feature globally
@@ -53,6 +53,7 @@ class FeatureToggle
   end
 
   # Method to check if a given feature is enabled for a user
+  # Note: this expects a User instance, not a CSS_ID
   def self.enabled?(feature, user: nil)
     return false unless features.include?(feature)
 
@@ -228,6 +229,12 @@ class FeatureToggle
       fail "Empty array for #{key}" if value.empty?
       fail "#{key} values have to be strings" if value.any? { |x| !x.is_a? String }
       fail "Empty string in #{key}" if value.any?(&:empty?)
+    end
+
+    # When feature toggles are enabled/disabled manually instead of through the config file
+    # This is to prevent errors if "users" is an array of Users instead of CSS_IDs
+    def css_ids_for_users(users)
+      users&.map { |user| user.is_a?(String) ? user : user.try(&:css_id) }
     end
   end
 end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -78,6 +78,14 @@ describe FeatureToggle do
         FeatureToggle.enable!(:test, users: [user3.css_id.downcase])
         expect(FeatureToggle.enabled?(:test, user: user3)).to eq true
       end
+
+      it "can be enabled using a User instance instead of CSS_ID" do
+        subject
+        FeatureToggle.enable!(:test, users: [user3])
+        expect(FeatureToggle.enabled?(:test, user: user1)).to eq true
+        expect(FeatureToggle.enabled?(:test, user: user2)).to eq false
+        expect(FeatureToggle.enabled?(:test, user: user3)).to eq true
+      end
     end
 
     context "for an RO and individual users" do
@@ -185,6 +193,13 @@ describe FeatureToggle do
       it "maintains access for regional offices" do
         subject
         expect(FeatureToggle.enabled?(:test, user: user2)).to eq true
+      end
+
+      it "can be disabled using a User instance instead of CSS_ID" do
+        subject
+        FeatureToggle.disable!(:test, users: [user2]
+        expect(FeatureToggle.enabled?(:test, user: user1)).to eq false
+        expect(FeatureToggle.enabled?(:test, user: user2)).to eq false
       end
     end
   end


### PR DESCRIPTION
The feature toggle `enable!` and `disable!` feature have an argument named `users` which expects an array of CSS_IDs.

This is probably because a feature config file wouldn't have access to the user objects, and instead lists CSS_IDs.

However, when feature toggles are enabled or disabled manually, this can cause an error if an array of User objects is passed instead of CSS_IDs, which could happen due to the naming and because this code is in another repo, it's not as obvious. This converts those to regular CSS_IDs.