### PR TITLE
jruuuu/APPEALS-13667: update jquery-rails 

### DIFF
--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
-  spec.add_runtime_dependency "jquery-rails"
+  spec.add_runtime_dependency "jquery-rails", "4.4"
   spec.add_runtime_dependency "redis-namespace"
   spec.add_runtime_dependency "redis-rails"
   # TODO drop d3-rails as Caseflow does not use it?


### PR DESCRIPTION
updated jquery-rails to 4.4 based on the security vulnerabilites report that needed to be resolved for bundle audit caseflow