### PR TITLE
APPEALS-27013 updated bourbon to 7.0.0 for rails update

### DIFF
--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "bourbon", "4.2.7"
+  spec.add_runtime_dependency "bourbon", "7.0.0"
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "bourbon", "7.0.0"
+  # spec.add_runtime_dependency "bourbon", "7.0.0"
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 
-  # spec.add_runtime_dependency "bourbon", "7.0.0"
+  spec.add_runtime_dependency "bourbon", ">= 7.0.0"
   spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.4.8"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
Jira [ticket](https://jira.devops.va.gov/browse/APPEALS-27013) for Bourbon gem update caseflow-commons.

## Description 
When working through the update path from our current Rails version to Rails 7.0, it was revealed that the Bourbon gem would need to be updated to >= 7.0.0 in order to make the jump from Rails 6.0 to 6.1. The change made here and in the two linked PR's below, for Caseflow and eFolder, are what's required for that update. 

Caseflow: [PR](https://github.com/department-of-veterans-affairs/caseflow/pull/19340)
eFolder: [PR](https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/1429)

## Additions
Caseflow-Commons: The only change was a restriction on the Bourbon gem to be >=7.0.0
Caseflow: Updated Gemfile and Gemfile.lock (Remove branch when merging to master)
eFolder: Updated Gemfile and Gemfile.lock (Remove branch when merging to master)

## Testing
Regression testing in UAT

