### PR TITLE
AlecK/APPEALS-27013

### DIFF
--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "bourbon", "4.2.7"
-  spec.add_runtime_dependency "neat"
+  # Delete after full testing
+  # spec.add_runtime_dependency "bourbon", "4.2.7"
+  # spec.add_runtime_dependency "neat"
 
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
   spec.add_runtime_dependency "jquery-rails"

--- a/caseflow.gemspec
+++ b/caseflow.gemspec
@@ -30,10 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 
-  # Delete after full testing
-  # spec.add_runtime_dependency "bourbon", "4.2.7"
-  # spec.add_runtime_dependency "neat"
-
   spec.add_runtime_dependency "rails", ">=4.2.7.1"
   spec.add_runtime_dependency "jquery-rails"
   spec.add_runtime_dependency "redis-namespace"

--- a/lib/caseflow/version.rb
+++ b/lib/caseflow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caseflow
-  VERSION = "0.4.8"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Resolves [APPEALS-27013](https://jira.devops.va.gov/browse/APPEALS-27013)

### Background
When we attempt to update either `caseflow` or `caseflow-efolder` to Rails 6.1, we will run up against a sub-dependency conflict between `rails` and `caseflow-commons` gems:

- `bundle udpate rails` output:

> Could not find compatible versions
> Because every version of caseflow depends on bourbon = 4.2.7
>   and bourbon >= 4.2.4, < 5.0.0.beta.6 depends on thor ~> 0.19,
>   every version of caseflow requires thor ~> 0.19.
> And because railties >= 6.1.0.rc1 depends on thor ~> 1.0
>   and rails >= 6.1.7.4, < 6.1.7.5 depends on railties = 6.1.7.4,
>   every version of caseflow is incompatible with rails >= 6.1.7.4, < 6.1.7.5.
> So, because Gemfile depends on caseflow >= 0
>   and Gemfile depends on rails = 6.1.7.4,
>   version solving has failed.

TL;DR – The sub-dependency `thor` needs to update to `> 1.0` in order to appease `rails` (via `railties`), however, it is being held back by `caseflow-commons` (via `bourbon (< 7.0.0)` and `neat (4.0.0)` dependencies on `thor ~> 0.19`). In short, we need to be able to relax `bourbon` to `> 7.0.0` (or remove it altogether) and also remove `neat`, such that `thor` can update to `~> 1.0` to the satisfaction of `railties`. 

Of the currently active repos dependent on `caseflow-commons`, it appears only `caseflow-efolder` has assets that depend on either the `bourbon` or `neat` gems. 

It turns out that we can remove the `bourbon` gem direct dependency from `caseflow-efolder`, since the `uswds-rails` gem includes its own copy of `bourbon 4.2.7` mixins (without the `bourbon` gem dependency).

Furthermore, `neat` grids aren't even being used in `caseflow-efolder` – it appears that `neat` got pulled in as a "stowaway" during a migration of styling assets out of `caseflow-commons` into eFolder and other repos (see PRs [caseflow-commons #153](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/153) & [caseflow-efolder #1002](https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/1002) .

So we should be able to dispense with both the `bourbon` and `neat` gem dependencies in `caseflow-commons` altogether, enabling us to upgrade both `caseflow` and `caseflow-efolder` to Rails 6.1 unencumbered by the conflicts mentioned above.

### Research / Due Diligence
Dependents on `bourbon` and `neat` via `caseflow-commons`
These are the repos found to be dependent on `caseflow-commons` ( [search](https://github.com/search?q=%2Fgem+%5B%22%27%5Dcaseflow%2F++user%3Adepartment-of-veterans-affairs&type=code&ref=advsearch) ):

[caseflow-efolder](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/5a9ddc9f4e041d9167cb842db18d6c6b03055fa9/Gemfile#L9)
The following repos can be disregarded as dependents on `bourbon` or `neat`:
    - [caseflow](https://github.com/department-of-veterans-affairs/caseflow/blob/5cb135b74516927381250c9bfbf89925816e139f/Gemfile#L20) : `bourbon` or `neat` not actually used in any assets
    - [caseflow-monitor](https://github.com/department-of-veterans-affairs/caseflow-monitor/blob/ff674146c3bb82928b5d2535d8c62fe6ae2ce7f4/Gemfile#L8): `bourbon` or `neat` not actually used in any assets
    - [caseflow-feedback](https://github.com/department-of-veterans-affairs/caseflow-feedback/blob/93ecedab5cf0f5aeb9aa2b61b0c85305f6ed3821/Gemfile#L7): This repository has been archived by the owner on Sep 14, 2022 (it is now read-only).
Of active repos dependent on `caseflow-commons`, only `caseflow-efolder` has a real asset dependency on  `bourbon` and `neat`:
    - [`bourbon` search](https://github.com/search?q=%2Fimport%20%5B%22%27%5Dbourbon%2F++user%3Adepartment-of-veterans-affairs&type=code&ref=advsearch) (`/import ["']bourbon/`)
        - [`caseflow-efolder` result](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/2773495e06c4e12405e842bf364ae51de07ffeb4/app/assets/stylesheets/_commons.scss#L1)
    - [`neat` search](https://github.com/search?q=%2Fimport+%5B%22%27%5Dneat%2F++user%3Adepartment-of-veterans-affairs&type=code&ref=advsearch) (`/import ["']neat/`)
        - [`caseflow-efolder` result](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/2773495e06c4e12405e842bf364ae51de07ffeb4/app/assets/stylesheets/_commons.scss#L2)
        
### Testing removal of `bourbon` and `neat` from `caseflow-commons` in eFolder
- We are `@include`-ing some `bourbon` Sass mixins in eFolder (eg. `@include clearfix;`)
- When we remove the `bourbon` gem & import, asset precompile is still successful, which suggests those `bourbon` mixins are still being defined somewhere
- It turns out that the `uswds_rails` gem, which is installed by eFolder, includes its own copy of `bourbon` (`v4.2.7`) mixin definitions (without the gem dependency)
- Since the `uswds_rails` assets were being `@import`-ed after the `bourbon` gem imports, they would have taken precedence over the `bourbon` gem definitions anyways.

### Steps taken
- Removed `bourbon` and `neat` dependencies from `caseflow-commons` gem and reinstalled locally
- In eFolder `Gemfile`, pointed `caseflow-commons` gem to local path
- `bundle update --conservative caseflow`
- Removed `bourbon` and `neat` imports from eFolder assets
- The app loaded successfully
- Attempted asset precompile, which ran without error:
    - `RAILS_ENV=development rails assets:precompile`
- Confirmed that `uswds_rails` is the source of the `bourbon` mixins by temporarily removing the `uswds_rails` definition of a mixin we are using (eg. the `clearfix` mixin) (locally), and observing an associated error during asset precompile:
    - `Sass::SyntaxError: Undefined mixin 'clearfix'.` was raised during assets precompile after removing the `@mixin clearfix` definitions from the following locations:
        - `~/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/uswds-rails-gem-aa12ddd31420/vendor/assets/stylesheets/uswds/lib/mixins/_clearfix.scss`
        - `~/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/uswds-rails-gem-aa12ddd31420/vendor/assets/stylesheets/uswds/lib/addons/_clearfix.scss`
        
 ### Proposed Solution
Remove both the `bourbon` and `neat` runtime dependencies from the gemspec
Bump `VERSION` (in `lib/caseflow/version.rb`) to `1.0.0`

### Changes
- Removed neat runtime dependency from gemspec
- Removed bourbon runtime dependency from gemspec
- Updated version to 1.0.0

### Testing
- Changes for APPEALS-27013 will be covered by regression testing for the Rails 6.1 updates for both Caseflow and eFolder.