### PR TITLE
Dev-Support/Add `workflow_dispatch` trigger for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+  workflow_dispatch:
   schedule:
     - cron: '27 2 * * 1'
 


### PR DESCRIPTION
# Description
Allows the CodeQL workflow to be manually triggered outside of its normal schedule.